### PR TITLE
Add exchange API modules and parsing tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""Crypto Calculator exchange clients."""
+
+from .binance import BinanceClient
+from .mexc import MEXCClient
+
+__all__ = ["BinanceClient", "MEXCClient"]

--- a/src/binance.py
+++ b/src/binance.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+# Placeholder configuration values
+API_KEY: str = "<YOUR_BINANCE_API_KEY>"
+API_SECRET: str = "<YOUR_BINANCE_API_SECRET>"
+RATE_LIMIT: int = 1200  # requests per minute
+
+
+@dataclass
+class BinanceClient:
+    """Simple Binance API client with placeholder authentication."""
+
+    api_key: str = API_KEY
+    api_secret: str = API_SECRET
+
+    def authenticate(self) -> bool:
+        """Validate API credentials. Placeholder implementation."""
+        return bool(self.api_key and self.api_secret)
+
+    def get_trade_history(self, raw_response: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Parse raw trade history API response.
+
+        Parameters
+        ----------
+        raw_response : List[Dict[str, Any]]
+            The response payload from Binance trades endpoint.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            Normalised trade history entries.
+        """
+        trades: List[Dict[str, Any]] = []
+        for trade in raw_response:
+            trades.append(
+                {
+                    "id": trade.get("id"),
+                    "symbol": trade.get("symbol"),
+                    "amount": float(trade.get("qty")),
+                    "price": float(trade.get("price")),
+                    "timestamp": int(trade.get("time")),
+                }
+            )
+        return trades

--- a/src/mexc.py
+++ b/src/mexc.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+# Placeholder configuration values
+API_KEY: str = "<YOUR_MEXC_API_KEY>"
+API_SECRET: str = "<YOUR_MEXC_API_SECRET>"
+RATE_LIMIT: int = 1000  # requests per minute
+
+
+@dataclass
+class MEXCClient:
+    """Simple MEXC API client with placeholder authentication."""
+
+    api_key: str = API_KEY
+    api_secret: str = API_SECRET
+
+    def authenticate(self) -> bool:
+        """Validate API credentials. Placeholder implementation."""
+        return bool(self.api_key and self.api_secret)
+
+    def get_trade_history(self, raw_response: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Parse raw trade history API response.
+
+        Parameters
+        ----------
+        raw_response : List[Dict[str, Any]]
+            The response payload from MEXC trades endpoint.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            Normalised trade history entries.
+        """
+        trades: List[Dict[str, Any]] = []
+        for trade in raw_response:
+            trades.append(
+                {
+                    "id": trade.get("id"),
+                    "symbol": trade.get("symbol"),
+                    "amount": float(trade.get("quantity")),
+                    "price": float(trade.get("price")),
+                    "timestamp": int(trade.get("timestamp")),
+                }
+            )
+        return trades

--- a/tests/test_binance.py
+++ b/tests/test_binance.py
@@ -1,0 +1,24 @@
+from crypto_calculator.binance import BinanceClient
+
+
+def test_parse_binance_trade_history():
+    client = BinanceClient()
+    sample_response = [
+        {
+            "id": 100,
+            "symbol": "BTCUSDT",
+            "qty": "0.1",
+            "price": "30000.0",
+            "time": 1609459200000,
+        }
+    ]
+    trades = client.get_trade_history(sample_response)
+    assert trades == [
+        {
+            "id": 100,
+            "symbol": "BTCUSDT",
+            "amount": 0.1,
+            "price": 30000.0,
+            "timestamp": 1609459200000,
+        }
+    ]

--- a/tests/test_mexc.py
+++ b/tests/test_mexc.py
@@ -1,0 +1,24 @@
+from crypto_calculator.mexc import MEXCClient
+
+
+def test_parse_mexc_trade_history():
+    client = MEXCClient()
+    sample_response = [
+        {
+            "id": 200,
+            "symbol": "ETHUSDT",
+            "quantity": "1.5",
+            "price": "2000.0",
+            "timestamp": 1609459200000,
+        }
+    ]
+    trades = client.get_trade_history(sample_response)
+    assert trades == [
+        {
+            "id": 200,
+            "symbol": "ETHUSDT",
+            "amount": 1.5,
+            "price": 2000.0,
+            "timestamp": 1609459200000,
+        }
+    ]


### PR DESCRIPTION
## Summary
- implement `BinanceClient` and `MEXCClient` modules with placeholder auth and trade history parsing
- export exchange clients from package
- add unit tests using sample API responses for both exchanges

## Testing
- `pip install -e .[test]` *(fails: Could not connect to PyPI)*
- `pytest -q` *(command not found)*