### PR TITLE
Implement PNL calculator with FIFO/LIFO

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,5 +2,6 @@
 
 from .binance import BinanceClient
 from .mexc import MEXCClient
+from .calculator import Trade, calculate_pnl
 
-__all__ = ["BinanceClient", "MEXCClient"]
+__all__ = ["BinanceClient", "MEXCClient", "Trade", "calculate_pnl"]

--- a/src/calculator.py
+++ b/src/calculator.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+"""Profit and loss calculation helpers.
+
+This module implements FIFO and LIFO cost basis methods as defined in the
+requirements document. FIFO (先入先出法) means "最初に取得した資産が最初に処分されるという在庫評価方法" and
+LIFO (後入先出法) means "最後に取得した資産が最初に処分されるという在庫評価方法".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+
+@dataclass
+class Trade:
+    """Normalised trade record.
+
+    Parameters
+    ----------
+    id : int
+        Unique identifier from the exchange.
+    symbol : str
+        Trading pair symbol.
+    amount : float
+        Quantity of the asset. Positive value represents a buy and negative
+        value represents a sell if ``side`` is not explicitly provided.
+    price : float
+        Trade price denominated in quote currency.
+    timestamp : int
+        Unix timestamp in milliseconds.
+    side : str | None
+        Optional trade side ("buy" or "sell"). If not provided the side is
+        determined from the sign of ``amount``.
+    """
+
+    id: int
+    symbol: str
+    amount: float
+    price: float
+    timestamp: int
+    side: str | None = None
+
+    def resolved_side(self) -> str:
+        if self.side:
+            return self.side.lower()
+        return "buy" if self.amount >= 0 else "sell"
+
+    def abs_amount(self) -> float:
+        return abs(self.amount)
+
+
+def _apply_sale(inventory: List[Dict[str, float]], amount: float, price: float, *, fifo: bool) -> float:
+    """Apply a sale to the inventory and return realised profit or loss."""
+    realised = 0.0
+    qty_to_sell = amount
+    while qty_to_sell > 0:
+        if not inventory:
+            raise ValueError("Insufficient inventory for sale")
+        item = inventory[0] if fifo else inventory[-1]
+        qty = min(item["amount"], qty_to_sell)
+        realised += qty * (price - item["price"])
+        item["amount"] -= qty
+        qty_to_sell -= qty
+        if item["amount"] == 0:
+            if fifo:
+                inventory.pop(0)
+            else:
+                inventory.pop()
+    return realised
+
+
+def calculate_pnl(trades: List[Dict[str, object]], method: str = "FIFO") -> float:
+    """Calculate realised profit/loss for a list of trades.
+
+    Trades should be dictionaries compatible with the data output by the data
+    retrieval modules. The following keys are expected: ``amount``, ``price``,
+    ``timestamp`` and optionally ``side``. When ``side`` is omitted a positive
+    ``amount`` is treated as a buy and a negative value as a sell.
+
+    Parameters
+    ----------
+    trades : List[Dict[str, object]]
+        Normalised trade dictionaries.
+    method : str
+        Calculation method either ``"FIFO"`` or ``"LIFO"``.
+
+    Returns
+    -------
+    float
+        The total realised profit or loss.
+    """
+    fifo = method.upper() == "FIFO"
+    inventory: List[Dict[str, float]] = []  # each item: {"amount": float, "price": float}
+    realised = 0.0
+    for raw in sorted(trades, key=lambda x: x["timestamp"]):
+        trade = Trade(**raw) if not isinstance(raw, Trade) else raw
+        side = trade.resolved_side()
+        amount = trade.abs_amount()
+        if side == "buy":
+            inventory.append({"amount": amount, "price": trade.price})
+        elif side == "sell":
+            realised += _apply_sale(inventory, amount, trade.price, fifo=fifo)
+        else:
+            raise ValueError(f"Unknown side: {side}")
+    return realised

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,29 @@
+from crypto_calculator import calculate_pnl
+
+
+def test_calculate_fifo_and_lifo():
+    trades = [
+        {"id": 1, "symbol": "BTCUSDT", "amount": 1.0, "price": 100.0, "timestamp": 1, "side": "buy"},
+        {"id": 2, "symbol": "BTCUSDT", "amount": 1.0, "price": 200.0, "timestamp": 2, "side": "buy"},
+        {"id": 3, "symbol": "BTCUSDT", "amount": 1.5, "price": 300.0, "timestamp": 3, "side": "sell"},
+    ]
+
+    fifo_pnl = calculate_pnl(trades, method="FIFO")
+    lifo_pnl = calculate_pnl(trades, method="LIFO")
+
+    assert fifo_pnl == 250.0
+    assert lifo_pnl == 200.0
+
+
+def test_calculate_with_implicit_side_and_insufficient_inventory():
+    trades = [
+        {"id": 10, "symbol": "ETHUSDT", "amount": 1.0, "price": 1000.0, "timestamp": 1},  # buy inferred
+        {"id": 11, "symbol": "ETHUSDT", "amount": -2.0, "price": 1100.0, "timestamp": 2},  # sell inferred
+    ]
+
+    try:
+        calculate_pnl(trades, method="FIFO")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for insufficient inventory")


### PR DESCRIPTION
## Summary
- add calculator module with FIFO and LIFO logic
- export calculate_pnl and Trade in package init
- unit tests for calculator covering FIFO, LIFO and errors

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
