### PR TITLE
Add reporting and CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Crypto Calculator
 
-暗号資産損益計算システムのリポジトリです。現在は基本的なPythonパッケージ構成のみが含まれており、実装はまだ行われていません。今後の開発計画については`要件定義書.md`に詳細があります。
+暗号資産損益計算システムのリポジトリです。基本的な取引履歴の解析や損益計算、
+簡易的なレポート出力を行うためのサンプル実装が含まれています。詳細な開発計画に
+ついては `要件定義書.md` を参照してください。
 
 ## セットアップ
 
@@ -18,9 +20,20 @@ pip install -e .[test]
 pytest
 ```
 
+## 使い方
+
+コマンドラインツール `crypto-calculator` を用いて、サンプルデータから
+損益計算を行い CSV と PDF のレポートを生成できます。
+
+```bash
+python -m crypto_calculator.main output/report --exchange binance --method FIFO
+```
+
+上記コマンドでは `output/report.csv` と `output/report.pdf` が作成されます。
+
 ## ディレクトリ構成
 
-- `src/` - パッケージ本体（現状は空です）
+- `src/` - パッケージ本体
 - `tests/` - テストコード
 - `要件定義書.md` - 日本語の要件定義書
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,5 +3,13 @@
 from .binance import BinanceClient
 from .mexc import MEXCClient
 from .calculator import Trade, calculate_pnl
+from .reporting import generate_csv_report, generate_pdf_report
 
-__all__ = ["BinanceClient", "MEXCClient", "Trade", "calculate_pnl"]
+__all__ = [
+    "BinanceClient",
+    "MEXCClient",
+    "Trade",
+    "calculate_pnl",
+    "generate_csv_report",
+    "generate_pdf_report",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,53 @@
+"""Command line interface for crypto calculator."""
+
+import argparse
+from typing import List, Dict
+
+from .binance import BinanceClient
+from .mexc import MEXCClient
+from .calculator import calculate_pnl
+from .reporting import generate_csv_report, generate_pdf_report
+
+
+def _sample_binance_data() -> List[Dict[str, object]]:
+    return [
+        {"id": 1, "symbol": "BTCUSDT", "qty": "0.1", "price": "30000.0", "time": 1609459200000},
+        {"id": 2, "symbol": "BTCUSDT", "qty": "-0.1", "price": "31000.0", "time": 1609462800000},
+    ]
+
+
+def _sample_mexc_data() -> List[Dict[str, object]]:
+    return [
+        {"id": 1, "symbol": "BTCUSDT", "quantity": "0.1", "price": "30000.0", "timestamp": 1609459200000},
+        {"id": 2, "symbol": "BTCUSDT", "quantity": "-0.1", "price": "31000.0", "timestamp": 1609462800000},
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Crypto Calculator CLI")
+    parser.add_argument("output", help="Output file path without extension")
+    parser.add_argument("--exchange", choices=["binance", "mexc"], default="binance")
+    parser.add_argument("--method", choices=["FIFO", "LIFO"], default="FIFO")
+    args = parser.parse_args()
+
+    if args.exchange == "binance":
+        client = BinanceClient()
+        trades = client.get_trade_history(_sample_binance_data())
+    else:
+        client = MEXCClient()
+        trades = client.get_trade_history(_sample_mexc_data())
+
+    pnl = calculate_pnl(trades, method=args.method)
+    summary = {"realised_pnl": pnl, "method": args.method}
+
+    csv_path = f"{args.output}.csv"
+    pdf_path = f"{args.output}.pdf"
+    generate_csv_report(summary, csv_path)
+    generate_pdf_report(summary, pdf_path)
+
+    print(f"CSV report saved to {csv_path}")
+    print(f"PDF report saved to {pdf_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -1,0 +1,46 @@
+"""Reporting utilities for CSV and PDF summaries."""
+
+from typing import Any, Dict
+import csv
+
+
+def generate_csv_report(summary: Dict[str, Any], filepath: str) -> None:
+    """Write summary dictionary to a CSV file.
+
+    Parameters
+    ----------
+    summary : Dict[str, Any]
+        Dictionary containing calculation results.
+    filepath : str
+        Destination CSV path.
+    """
+    with open(filepath, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["key", "value"])
+        for key, value in summary.items():
+            writer.writerow([key, value])
+
+
+def generate_pdf_report(summary: Dict[str, Any], filepath: str) -> None:
+    """Write summary dictionary to a PDF file.
+
+    If the optional ``fpdf`` package is available it will be used to generate a
+    simple PDF. Otherwise the report is written as plain text with a ``.pdf``
+    extension.
+    """
+    try:
+        from fpdf import FPDF  # type: ignore
+    except Exception:
+        with open(filepath, "w") as f:
+            for key, value in summary.items():
+                f.write(f"{key}: {value}\n")
+        return
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, "Calculation Summary", ln=True, align="C")
+    pdf.ln(5)
+    for key, value in summary.items():
+        pdf.cell(0, 10, f"{key}: {value}", ln=True)
+    pdf.output(filepath)


### PR DESCRIPTION
## Summary
- implement `reporting.py` with CSV/PDF export helpers
- add simple command line interface in `main.py`
- export reporting helpers in package init
- document command usage in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*