### PR TITLE
Add console script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pytest
 損益計算を行い CSV と PDF のレポートを生成できます。
 
 ```bash
-python -m crypto_calculator.main output/report --exchange binance --method FIFO
+crypto-calculator output/report --exchange binance --method FIFO
 ```
 
 上記コマンドでは `output/report.csv` と `output/report.pdf` が作成されます。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = ["pytest"]
+
+[project.scripts]
+crypto-calculator = "crypto_calculator.main:main"


### PR DESCRIPTION
## Summary
- add console entry point for `crypto-calculator`
- update example usage in README

## Testing
- `pytest -q` *(fails: No module named pytest)*