### PR TITLE
Add Flask-based dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ crypto-calculator output/report --exchange binance --method FIFO
 python -m crypto_calculator.main output/report --csv trades.csv --method FIFO
 ```
 
+計算結果を Web ブラウザで確認したい場合は `--serve` オプションを利用します。
+
+```bash
+crypto-calculator output/report --serve
+```
+
 CSV ファイルは以下のような形式を想定しています。
 
 ```csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "crypto-calculator"
 version = "0.1.0"
 description = "Cryptocurrency profit and loss calculation system"
 requires-python = ">=3.8"
+dependencies = ["flask"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,7 @@ from .mexc import MEXCClient
 from .calculator import Trade, calculate_pnl
 from .reporting import generate_csv_report, generate_pdf_report
 from .csv_import import read_trades_from_csv
+from .dashboard import run_dashboard
 
 __all__ = [
     "BinanceClient",
@@ -14,4 +15,5 @@ __all__ = [
     "generate_csv_report",
     "generate_pdf_report",
     "read_trades_from_csv",
+    "run_dashboard",
 ]

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,0 +1,25 @@
+"""Simple Flask dashboard to display calculation results."""
+
+from typing import Any, Dict
+
+from flask import Flask
+
+
+def create_app(summary: Dict[str, Any]) -> Flask:
+    """Create a Flask application showing the calculation summary."""
+
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index() -> str:
+        lines = [f"{key}: {value}" for key, value in summary.items()]
+        return "<br>".join(lines)
+
+    return app
+
+
+def run_dashboard(summary: Dict[str, Any]) -> None:
+    """Run the dashboard web server."""
+
+    app = create_app(summary)
+    app.run()

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,8 @@
 import argparse
 from typing import List, Dict
 
+from .dashboard import run_dashboard
+
 from .binance import BinanceClient
 from .mexc import MEXCClient
 from .calculator import calculate_pnl
@@ -30,6 +32,7 @@ def main() -> None:
     parser.add_argument("--exchange", choices=["binance", "mexc"], default="binance")
     parser.add_argument("--method", choices=["FIFO", "LIFO"], default="FIFO")
     parser.add_argument("--csv", help="Path to CSV file containing trades")
+    parser.add_argument("--serve", action="store_true", help="Run dashboard web server")
     args = parser.parse_args()
 
     if args.csv:
@@ -52,6 +55,9 @@ def main() -> None:
 
     print(f"CSV report saved to {csv_path}")
     print(f"PDF report saved to {pdf_path}")
+
+    if args.serve:
+        run_dashboard(summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `flask` dependency
- implement simple dashboard module
- expose dashboard function in package
- enable `--serve` option in CLI to run dashboard
- document how to start the dashboard

## Testing
- `pytest -q` *(fails: command not found)*