### PR TITLE
Use REST APIs to fetch trade history

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@
 pip install -e .
 ```
 
+API から取引履歴を取得する場合は、以下の環境変数に各取引所の API キーとシークレットを設定してください。
+
+```
+export BINANCE_API_KEY=<your key>
+export BINANCE_API_SECRET=<your secret>
+export MEXC_API_KEY=<your key>
+export MEXC_API_SECRET=<your secret>
+```
+
 テストを実行する場合は `test` というオプション依存関係を使用します。
 
 ```bash
@@ -22,11 +31,11 @@ pytest
 
 ## 使い方
 
-コマンドラインツール `crypto-calculator` を用いて、サンプルデータから
-損益計算を行い CSV と PDF のレポートを生成できます。
+コマンドラインツール `crypto-calculator` を用いると、取引所 API から取得した
+取引履歴をもとに損益計算を行い CSV と PDF のレポートを生成できます。
 
 ```bash
-crypto-calculator output/report --exchange binance --method FIFO
+crypto-calculator output/report --exchange binance --method FIFO --symbol BTCUSDT
 ```
 
 上記コマンドでは `output/report.csv` と `output/report.pdf` が作成されます。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "Cryptocurrency profit and loss calculation system"
 requires-python = ">=3.8"
 
+[project.dependencies]
+requests = "*"
+
 [project.optional-dependencies]
 test = ["pytest"]
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,38 @@
+"""User authentication utilities."""
+
+from dataclasses import dataclass
+import hashlib
+import os
+import base64
+
+
+@dataclass
+class User:
+    """User account information."""
+
+    id: int | None
+    username: str
+    password_hash: str
+    salt: str
+
+    def verify_password(self, password: str) -> bool:
+        """Verify a password against the stored hash."""
+        salt_bytes = base64.b64decode(self.salt)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, 100000)
+        return base64.b64encode(hashed).decode() == self.password_hash
+
+    @staticmethod
+    def hash_password(password: str) -> tuple[str, str]:
+        """Create a password hash and salt for storage."""
+        salt = os.urandom(16)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return (
+            base64.b64encode(hashed).decode(),
+            base64.b64encode(salt).decode(),
+        )
+
+    @classmethod
+    def create(cls, username: str, password: str) -> "User":
+        """Create a new ``User`` instance from plaintext password."""
+        password_hash, salt = cls.hash_password(password)
+        return cls(id=None, username=username, password_hash=password_hash, salt=salt)

--- a/src/binance.py
+++ b/src/binance.py
@@ -1,36 +1,48 @@
-from dataclasses import dataclass
-from typing import Any, Dict, List
+"""Binance REST API client."""
 
-# Placeholder configuration values
-API_KEY: str = "<YOUR_BINANCE_API_KEY>"
-API_SECRET: str = "<YOUR_BINANCE_API_SECRET>"
-RATE_LIMIT: int = 1200  # requests per minute
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+import os
+import time
+import hmac
+import hashlib
+from urllib.parse import urlencode
+import requests
+
+BASE_URL = "https://api.binance.com"
+API_KEY_ENV = "BINANCE_API_KEY"
+API_SECRET_ENV = "BINANCE_API_SECRET"
+RATE_LIMIT = 1200  # requests per minute
 
 
 @dataclass
 class BinanceClient:
-    """Simple Binance API client with placeholder authentication."""
+    """Minimal Binance API client."""
 
-    api_key: str = API_KEY
-    api_secret: str = API_SECRET
+    api_key: str = field(default_factory=lambda: os.getenv(API_KEY_ENV, ""))
+    api_secret: str = field(default_factory=lambda: os.getenv(API_SECRET_ENV, ""))
 
     def authenticate(self) -> bool:
-        """Validate API credentials. Placeholder implementation."""
+        """Validate API credentials."""
         return bool(self.api_key and self.api_secret)
 
-    def get_trade_history(self, raw_response: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Parse raw trade history API response.
+    def get_trade_history(self, symbol: str) -> List[Dict[str, Any]]:
+        """Fetch trade history from Binance and normalise the result."""
 
-        Parameters
-        ----------
-        raw_response : List[Dict[str, Any]]
-            The response payload from Binance trades endpoint.
+        if not self.authenticate():
+            raise ValueError("Invalid API credentials")
 
-        Returns
-        -------
-        List[Dict[str, Any]]
-            Normalised trade history entries.
-        """
+        timestamp = int(time.time() * 1000)
+        params = {"symbol": symbol, "timestamp": timestamp}
+        query = urlencode(params)
+        signature = hmac.new(self.api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        params["signature"] = signature
+        headers = {"X-MBX-APIKEY": self.api_key}
+
+        response = requests.get(f"{BASE_URL}/api/v3/myTrades", params=params, headers=headers, timeout=10)
+        response.raise_for_status()
+
+        raw_response = response.json()
         trades: List[Dict[str, Any]] = []
         for trade in raw_response:
             trades.append(

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,54 @@
+"""SQLite database helpers for user management."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from .auth import User
+
+DB_PATH = Path(__file__).resolve().parent / "users.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db() -> None:
+    """Create users table if it does not already exist."""
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                salt TEXT NOT NULL
+            )
+            """
+        )
+
+
+def add_user(username: str, password: str) -> User:
+    """Create and persist a new user."""
+    user = User.create(username, password)
+    with get_connection() as conn:
+        cur = conn.execute(
+            "INSERT INTO users (username, password_hash, salt) VALUES (?, ?, ?)",
+            (user.username, user.password_hash, user.salt),
+        )
+        user.id = cur.lastrowid
+    return user
+
+
+def get_user_by_username(username: str) -> Optional[User]:
+    """Retrieve a user by username."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id, username, password_hash, salt FROM users WHERE username=?",
+            (username,),
+        ).fetchone()
+    if row:
+        return User(*row)
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,8 @@
 import argparse
 from typing import List, Dict
 
+from .db import init_db, add_user, get_user_by_username
+
 from .binance import BinanceClient
 from .mexc import MEXCClient
 from .calculator import calculate_pnl
@@ -10,37 +12,58 @@ from .reporting import generate_csv_report, generate_pdf_report
 from .csv_import import read_trades_from_csv
 
 
-def _sample_binance_data() -> List[Dict[str, object]]:
-    return [
-        {"id": 1, "symbol": "BTCUSDT", "qty": "0.1", "price": "30000.0", "time": 1609459200000},
-        {"id": 2, "symbol": "BTCUSDT", "qty": "-0.1", "price": "31000.0", "time": 1609462800000},
-    ]
-
-
-def _sample_mexc_data() -> List[Dict[str, object]]:
-    return [
-        {"id": 1, "symbol": "BTCUSDT", "quantity": "0.1", "price": "30000.0", "timestamp": 1609459200000},
-        {"id": 2, "symbol": "BTCUSDT", "quantity": "-0.1", "price": "31000.0", "timestamp": 1609462800000},
-    ]
 
 
 def main() -> None:
+    init_db()
+
     parser = argparse.ArgumentParser(description="Crypto Calculator CLI")
-    parser.add_argument("output", help="Output file path without extension")
+    subparsers = parser.add_subparsers(dest="command")
+
+    register_p = subparsers.add_parser("register", help="Register new user")
+    register_p.add_argument("username")
+    register_p.add_argument("password")
+
+    login_p = subparsers.add_parser("login", help="Authenticate user")
+    login_p.add_argument("username")
+    login_p.add_argument("password")
+
+    # Arguments for calculation (default command)
+    parser.add_argument("output", nargs="?", help="Output file path without extension")
     parser.add_argument("--exchange", choices=["binance", "mexc"], default="binance")
     parser.add_argument("--method", choices=["FIFO", "LIFO"], default="FIFO")
     parser.add_argument("--csv", help="Path to CSV file containing trades")
+    parser.add_argument("--symbol", default="BTCUSDT", help="Trading pair symbol")
     args = parser.parse_args()
+
+    if args.command == "register":
+        user = add_user(args.username, args.password)
+        print(f"Registered user {user.username} (id: {user.id})")
+        return
+    if args.command == "login":
+        user = get_user_by_username(args.username)
+        if not user:
+            print("User not found")
+            return
+        if user.verify_password(args.password):
+            print("Login successful")
+        else:
+            print("Invalid password")
+        return
+
+    if not args.output:
+        parser.print_help()
+        return
 
     if args.csv:
         trades = read_trades_from_csv(args.csv)
     else:
         if args.exchange == "binance":
             client = BinanceClient()
-            trades = client.get_trade_history(_sample_binance_data())
+            trades = client.get_trade_history(args.symbol)
         else:
             client = MEXCClient()
-            trades = client.get_trade_history(_sample_mexc_data())
+            trades = client.get_trade_history(args.symbol)
 
     pnl = calculate_pnl(trades, method=args.method)
     summary = {"realised_pnl": pnl, "method": args.method}

--- a/src/mexc.py
+++ b/src/mexc.py
@@ -1,36 +1,48 @@
-from dataclasses import dataclass
-from typing import Any, Dict, List
+"""MEXC REST API client."""
 
-# Placeholder configuration values
-API_KEY: str = "<YOUR_MEXC_API_KEY>"
-API_SECRET: str = "<YOUR_MEXC_API_SECRET>"
-RATE_LIMIT: int = 1000  # requests per minute
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+import os
+import time
+import hmac
+import hashlib
+from urllib.parse import urlencode
+import requests
+
+BASE_URL = "https://api.mexc.com"
+API_KEY_ENV = "MEXC_API_KEY"
+API_SECRET_ENV = "MEXC_API_SECRET"
+RATE_LIMIT = 1000  # requests per minute
 
 
 @dataclass
 class MEXCClient:
-    """Simple MEXC API client with placeholder authentication."""
+    """Minimal MEXC API client."""
 
-    api_key: str = API_KEY
-    api_secret: str = API_SECRET
+    api_key: str = field(default_factory=lambda: os.getenv(API_KEY_ENV, ""))
+    api_secret: str = field(default_factory=lambda: os.getenv(API_SECRET_ENV, ""))
 
     def authenticate(self) -> bool:
-        """Validate API credentials. Placeholder implementation."""
+        """Validate API credentials."""
         return bool(self.api_key and self.api_secret)
 
-    def get_trade_history(self, raw_response: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Parse raw trade history API response.
+    def get_trade_history(self, symbol: str) -> List[Dict[str, Any]]:
+        """Fetch trade history from MEXC and normalise the result."""
 
-        Parameters
-        ----------
-        raw_response : List[Dict[str, Any]]
-            The response payload from MEXC trades endpoint.
+        if not self.authenticate():
+            raise ValueError("Invalid API credentials")
 
-        Returns
-        -------
-        List[Dict[str, Any]]
-            Normalised trade history entries.
-        """
+        timestamp = int(time.time() * 1000)
+        params = {"symbol": symbol, "timestamp": timestamp}
+        query = urlencode(params)
+        signature = hmac.new(self.api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        params["signature"] = signature
+        headers = {"X-MEXC-APIKEY": self.api_key}
+
+        response = requests.get(f"{BASE_URL}/api/v3/private/trades", params=params, headers=headers, timeout=10)
+        response.raise_for_status()
+
+        raw_response = response.json()
         trades: List[Dict[str, Any]] = []
         for trade in raw_response:
             trades.append(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,7 @@
+from crypto_calculator.auth import User
+
+
+def test_password_hashing_and_verification():
+    user = User.create("alice", "secret")
+    assert user.verify_password("secret")
+    assert not user.verify_password("wrong")

--- a/tests/test_binance.py
+++ b/tests/test_binance.py
@@ -1,9 +1,20 @@
+import requests
 from crypto_calculator.binance import BinanceClient
 
 
-def test_parse_binance_trade_history():
-    client = BinanceClient()
-    sample_response = [
+class MockResp:
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return self.data
+
+
+def test_get_binance_trade_history(monkeypatch):
+    sample_json = [
         {
             "id": 100,
             "symbol": "BTCUSDT",
@@ -12,7 +23,16 @@ def test_parse_binance_trade_history():
             "time": 1609459200000,
         }
     ]
-    trades = client.get_trade_history(sample_response)
+
+    def mock_get(url, params=None, headers=None, timeout=10):
+        return MockResp(sample_json)
+
+    monkeypatch.setenv("BINANCE_API_KEY", "key")
+    monkeypatch.setenv("BINANCE_API_SECRET", "secret")
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    client = BinanceClient()
+    trades = client.get_trade_history("BTCUSDT")
     assert trades == [
         {
             "id": 100,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,12 @@
+from crypto_calculator.db import init_db, add_user, get_user_by_username
+
+
+def test_add_and_get_user(tmp_path, monkeypatch):
+    db_file = tmp_path / "users.db"
+    monkeypatch.setattr("crypto_calculator.db.DB_PATH", db_file)
+    init_db()
+    user = add_user("bob", "password")
+    fetched = get_user_by_username("bob")
+    assert fetched is not None
+    assert fetched.username == "bob"
+    assert fetched.verify_password("password")

--- a/tests/test_mexc.py
+++ b/tests/test_mexc.py
@@ -1,9 +1,20 @@
+import requests
 from crypto_calculator.mexc import MEXCClient
 
 
-def test_parse_mexc_trade_history():
-    client = MEXCClient()
-    sample_response = [
+class MockResp:
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return self.data
+
+
+def test_get_mexc_trade_history(monkeypatch):
+    sample_json = [
         {
             "id": 200,
             "symbol": "ETHUSDT",
@@ -12,7 +23,16 @@ def test_parse_mexc_trade_history():
             "timestamp": 1609459200000,
         }
     ]
-    trades = client.get_trade_history(sample_response)
+
+    def mock_get(url, params=None, headers=None, timeout=10):
+        return MockResp(sample_json)
+
+    monkeypatch.setenv("MEXC_API_KEY", "key")
+    monkeypatch.setenv("MEXC_API_SECRET", "secret")
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    client = MEXCClient()
+    trades = client.get_trade_history("ETHUSDT")
     assert trades == [
         {
             "id": 200,


### PR DESCRIPTION
## Summary
- depend on `requests`
- fetch trade history from Binance and MEXC with REST APIs
- load API keys from environment variables
- support `--symbol` in CLI while keeping auth features
- document environment variables in README
- update tests for new API behaviour

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*