### PR TITLE
Add Flask-based dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ crypto-calculator output/report --exchange binance --method FIFO
 python -m crypto_calculator.main output/report --csv trades.csv --method FIFO
 ```
 
+計算結果を Web ブラウザで確認したい場合は `--serve` オプションを利用します。
+
+```bash
+crypto-calculator output/report --serve
+```
+
 CSV ファイルは以下のような形式を想定しています。
 
 ```csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "crypto-calculator"
 version = "0.1.0"
 description = "Cryptocurrency profit and loss calculation system"
 requires-python = ">=3.8"
+dependencies = ["flask"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,7 @@ from .mexc import MEXCClient
 from .calculator import Trade, calculate_pnl
 from .reporting import generate_csv_report, generate_pdf_report
 from .csv_import import read_trades_from_csv
+from .dashboard import run_dashboard
 
 __all__ = [
     "BinanceClient",
@@ -14,4 +15,5 @@ __all__ = [
     "generate_csv_report",
     "generate_pdf_report",
     "read_trades_from_csv",
+    "run_dashboard",
 ]

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,38 @@
+"""User authentication utilities."""
+
+from dataclasses import dataclass
+import hashlib
+import os
+import base64
+
+
+@dataclass
+class User:
+    """User account information."""
+
+    id: int | None
+    username: str
+    password_hash: str
+    salt: str
+
+    def verify_password(self, password: str) -> bool:
+        """Verify a password against the stored hash."""
+        salt_bytes = base64.b64decode(self.salt)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, 100000)
+        return base64.b64encode(hashed).decode() == self.password_hash
+
+    @staticmethod
+    def hash_password(password: str) -> tuple[str, str]:
+        """Create a password hash and salt for storage."""
+        salt = os.urandom(16)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return (
+            base64.b64encode(hashed).decode(),
+            base64.b64encode(salt).decode(),
+        )
+
+    @classmethod
+    def create(cls, username: str, password: str) -> "User":
+        """Create a new ``User`` instance from plaintext password."""
+        password_hash, salt = cls.hash_password(password)
+        return cls(id=None, username=username, password_hash=password_hash, salt=salt)

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,0 +1,25 @@
+"""Simple Flask dashboard to display calculation results."""
+
+from typing import Any, Dict
+
+from flask import Flask
+
+
+def create_app(summary: Dict[str, Any]) -> Flask:
+    """Create a Flask application showing the calculation summary."""
+
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index() -> str:
+        lines = [f"{key}: {value}" for key, value in summary.items()]
+        return "<br>".join(lines)
+
+    return app
+
+
+def run_dashboard(summary: Dict[str, Any]) -> None:
+    """Run the dashboard web server."""
+
+    app = create_app(summary)
+    app.run()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,54 @@
+"""SQLite database helpers for user management."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from .auth import User
+
+DB_PATH = Path(__file__).resolve().parent / "users.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db() -> None:
+    """Create users table if it does not already exist."""
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                salt TEXT NOT NULL
+            )
+            """
+        )
+
+
+def add_user(username: str, password: str) -> User:
+    """Create and persist a new user."""
+    user = User.create(username, password)
+    with get_connection() as conn:
+        cur = conn.execute(
+            "INSERT INTO users (username, password_hash, salt) VALUES (?, ?, ?)",
+            (user.username, user.password_hash, user.salt),
+        )
+        user.id = cur.lastrowid
+    return user
+
+
+def get_user_by_username(username: str) -> Optional[User]:
+    """Retrieve a user by username."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id, username, password_hash, salt FROM users WHERE username=?",
+            (username,),
+        ).fetchone()
+    if row:
+        return User(*row)
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,9 @@
 import argparse
 from typing import List, Dict
 
+from .dashboard import run_dashboard
+from .db import init_db, add_user, get_user_by_username
+
 from .binance import BinanceClient
 from .mexc import MEXCClient
 from .calculator import calculate_pnl
@@ -25,12 +28,45 @@ def _sample_mexc_data() -> List[Dict[str, object]]:
 
 
 def main() -> None:
+    init_db()
+
     parser = argparse.ArgumentParser(description="Crypto Calculator CLI")
-    parser.add_argument("output", help="Output file path without extension")
+    subparsers = parser.add_subparsers(dest="command")
+
+    register_p = subparsers.add_parser("register", help="Register new user")
+    register_p.add_argument("username")
+    register_p.add_argument("password")
+
+    login_p = subparsers.add_parser("login", help="Authenticate user")
+    login_p.add_argument("username")
+    login_p.add_argument("password")
+
+    # Arguments for calculation (default command)
+    parser.add_argument("output", nargs="?", help="Output file path without extension")
     parser.add_argument("--exchange", choices=["binance", "mexc"], default="binance")
     parser.add_argument("--method", choices=["FIFO", "LIFO"], default="FIFO")
     parser.add_argument("--csv", help="Path to CSV file containing trades")
+    parser.add_argument("--serve", action="store_true", help="Run dashboard web server")
     args = parser.parse_args()
+
+    if args.command == "register":
+        user = add_user(args.username, args.password)
+        print(f"Registered user {user.username} (id: {user.id})")
+        return
+    if args.command == "login":
+        user = get_user_by_username(args.username)
+        if not user:
+            print("User not found")
+            return
+        if user.verify_password(args.password):
+            print("Login successful")
+        else:
+            print("Invalid password")
+        return
+
+    if not args.output:
+        parser.print_help()
+        return
 
     if args.csv:
         trades = read_trades_from_csv(args.csv)
@@ -52,6 +88,9 @@ def main() -> None:
 
     print(f"CSV report saved to {csv_path}")
     print(f"PDF report saved to {pdf_path}")
+
+    if args.serve:
+        run_dashboard(summary)
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,7 @@
+from crypto_calculator.auth import User
+
+
+def test_password_hashing_and_verification():
+    user = User.create("alice", "secret")
+    assert user.verify_password("secret")
+    assert not user.verify_password("wrong")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,12 @@
+from crypto_calculator.db import init_db, add_user, get_user_by_username
+
+
+def test_add_and_get_user(tmp_path, monkeypatch):
+    db_file = tmp_path / "users.db"
+    monkeypatch.setattr("crypto_calculator.db.DB_PATH", db_file)
+    init_db()
+    user = add_user("bob", "password")
+    fetched = get_user_by_username("bob")
+    assert fetched is not None
+    assert fetched.username == "bob"
+    assert fetched.verify_password("password")


### PR DESCRIPTION
## Summary
- add `flask` dependency
- implement simple dashboard module
- export dashboard function in package
- integrate dashboard with CLI and authentication commands
- document `--serve` usage in README

## Testing
- `pytest -q` *(fails: command not found)*