### PR TITLE
fix: add null check for gain_loss to prevent TypeError

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -283,7 +283,7 @@ export default function Dashboard() {
                         ${tx.fee.toFixed(2)}
                       </td>
                       <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-900">
-                        {tx.gain_loss !== undefined && (
+                        {tx.gain_loss !== undefined && tx.gain_loss !== null && (
                           <span
                             className={
                               tx.gain_loss >= 0


### PR DESCRIPTION
### Description

Fixed the TypeError that occurred when clicking the profit/loss calculation button.

### Changes
- Added null check before calling `toFixed()` on `tx.gain_loss`
- Prevents "Cannot read properties of null (reading 'toFixed')" error
- Only sell transactions have gain_loss values, buy transactions have null

Fixes #30

Generated with [Claude Code](https://claude.ai/code)