### PR TITLE
feat: add date range filtering to transactions dashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -440,6 +440,8 @@ async def get_transactions_filtered(
     offset: int = 0,
     type: Optional[str] = None,
     currency: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     current_user: User = Depends(get_current_user)
 ):
     """Get filtered transactions with pagination."""
@@ -449,7 +451,9 @@ async def get_transactions_filtered(
             limit=limit,
             offset=offset,
             type_filter=type,
-            currency_filter=currency
+            currency_filter=currency,
+            start_date=start_date,
+            end_date=end_date
         )
         
         return TransactionsFilteredResponse(

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -36,6 +36,8 @@ export default function Dashboard() {
   const [typeFilter, setTypeFilter] = useState<"buy" | "sell" | "both">("both");
   const [currencyFilter, setCurrencyFilter] = useState("");
   const [availableCurrencies, setAvailableCurrencies] = useState<string[]>([]);
+  const [startDateFilter, setStartDateFilter] = useState("");
+  const [endDateFilter, setEndDateFilter] = useState("");
 
   // Form state
   const [date, setDate] = useState("");
@@ -84,6 +86,14 @@ export default function Dashboard() {
           params.append("currency", currencyFilter);
         }
         
+        if (startDateFilter) {
+          params.append("start_date", startDateFilter);
+        }
+        
+        if (endDateFilter) {
+          params.append("end_date", endDateFilter);
+        }
+        
         const response = await axios.get(`/api/transactions/filtered?${params}`);
         setTransactions(response.data.transactions);
         setTotalItems(response.data.total);
@@ -95,7 +105,7 @@ export default function Dashboard() {
       }
     };
     loadTransactions();
-  }, [currentPage, itemsPerPage, typeFilter, currencyFilter]);
+  }, [currentPage, itemsPerPage, typeFilter, currencyFilter, startDateFilter, endDateFilter]);
 
   // Load available currencies on component mount
   useEffect(() => {
@@ -270,6 +280,14 @@ export default function Dashboard() {
         
         if (currencyFilter) {
           params.append("currency", currencyFilter);
+        }
+        
+        if (startDateFilter) {
+          params.append("start_date", startDateFilter);
+        }
+        
+        if (endDateFilter) {
+          params.append("end_date", endDateFilter);
         }
         
         const reloadResponse = await axios.get(`/api/transactions/filtered?${params}`);
@@ -526,6 +544,33 @@ export default function Dashboard() {
                       </option>
                     ))}
                   </select>
+                </div>
+                
+                {/* Date range filters */}
+                <div className="flex items-center gap-2">
+                  <label className="text-sm text-gray-700">From:</label>
+                  <input
+                    type="date"
+                    value={startDateFilter}
+                    onChange={(e) => {
+                      setStartDateFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                    className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  />
+                </div>
+                
+                <div className="flex items-center gap-2">
+                  <label className="text-sm text-gray-700">To:</label>
+                  <input
+                    type="date"
+                    value={endDateFilter}
+                    onChange={(e) => {
+                      setEndDateFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                    className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  />
                 </div>
               </div>
             </div>

--- a/src/db.py
+++ b/src/db.py
@@ -153,7 +153,9 @@ def get_user_transactions_filtered(
     limit: int = 10,
     offset: int = 0,
     type_filter: Optional[str] = None,
-    currency_filter: Optional[str] = None
+    currency_filter: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None
 ) -> Dict[str, Any]:
     """Get filtered transactions for a specific user with pagination."""
     with get_connection() as conn:
@@ -170,6 +172,14 @@ def get_user_transactions_filtered(
         if currency_filter:
             where_clauses.append("currency = ?")
             params.append(currency_filter.upper())
+        
+        if start_date:
+            where_clauses.append("date >= ?")
+            params.append(start_date)
+        
+        if end_date:
+            where_clauses.append("date <= ?")
+            params.append(end_date)
         
         where_clause = " AND ".join(where_clauses)
         


### PR DESCRIPTION
Implements date range filtering feature requested in #60

## Changes
- Added date range filtering to the transactions dashboard
- Users can now filter transactions by start and end dates
- Date inputs are added to the filter controls section

## Implementation Details
- Updated backend API to accept start_date and end_date query parameters
- Modified get_user_transactions_filtered function to support date filtering
- Added date range input fields (From/To) to the dashboard filter controls
- Updated frontend to include date parameters in API requests

Closes #60

Generated with [Claude Code](https://claude.ai/code)